### PR TITLE
Wi-fi radio operations require interface to be UP before they will be actioned - 2nd attempt

### DIFF
--- a/poky/meta-squeezeos/packages/wpa-supplicant/files/wifi_interface_up_baby
+++ b/poky/meta-squeezeos/packages/wpa-supplicant/files/wifi_interface_up_baby
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Keep the wireless interface scanning
+
+# After ifdown, the interface  may be left "down". This
+# will prevent wpa_supplicant > v0.7.2 from undertaking SCAN,
+# REASSOCIATE, and other wi-fi radio operations.
+
+if [ "$IFACE"x = eth1x ]; then
+	/bin/ip addr flush dev eth1 2>/dev/null
+	/bin/ip link set eth1 up
+fi

--- a/poky/meta-squeezeos/packages/wpa-supplicant/wpa-supplicant_2.9.bb
+++ b/poky/meta-squeezeos/packages/wpa-supplicant/wpa-supplicant_2.9.bb
@@ -7,6 +7,10 @@ PR = "r0"
 SRC_URI = "http://w1.fi/releases/wpa_supplicant-${PV}.tar.gz \
 	   file://defconfig"
 
+SRC_URI_append_baby = " \
+	file://wifi_interface_up_baby \
+	"
+
 S = "${WORKDIR}/wpa_supplicant-${PV}/wpa_supplicant"
 
 # With the csl2010q1 and high optimization it fails. 'arm' instruction set to be safe
@@ -32,8 +36,14 @@ do_install() {
 	install -m 0755 ${S}/wpa_cli ${D}${sbindir}/wpa_cli
 }
 
+do_install_append_baby() {
+	# network script - ensure interface (eth1) is raised back 'up' after 'ifdown'
+	install -m 0755 -d ${D}${sysconfdir}/network/if-post-down.d
+	install -m 0755 ${WORKDIR}/wifi_interface_up_baby ${D}${sysconfdir}/network/if-post-down.d/wifi_interface_up
+}
+
 PACKAGES = "wpa-supplicant-dbg wpa-supplicant"
 
-FILES_wpa-supplicant = "${sbindir}"
+FILES_wpa-supplicant = "${sbindir} ${sysconfdir}"
 FILES_wpa-supplicant-dbg = "${sbindir}.debug"
 


### PR DESCRIPTION
This is very much a draft proposal that seeks to handle an issue raised in issue _Summary of wifi issues under wpa_supplicant 2.9_. Specifically here: ralph-irving/squeezeos-squeezeplay#5 (comment).

**NOTE:** I have not been able to check that it builds properly in poky as I don't have access to a build platform at present. I may well have made errors. I offer it as a "proof of concept" patch.

The intention is that an 'ifdown' action script be installed on the SqueezeboxRadio to counter the adverse impact that 'ifdown' has on the ability of wpa_supplicant to undertake SCAN and REASSOCIATE commands.

The installed script appears to operate as expected on the Radio, but confirmation/review welcome.

I have "hosted" the change within the wpa_supplicant v2.9 package, on the premise that that is where it belongs. And, at present, its action is limited to the 'baby' build.