### PR TITLE
wpa_supplicant v2.9 - Fix "Wireless Event too big (33)" messages

### DIFF
--- a/poky/meta-squeezeos/packages/wpa-supplicant/files/bogus-SSID-too-long_2.9.patch
+++ b/poky/meta-squeezeos/packages/wpa-supplicant/files/bogus-SSID-too-long_2.9.patch
@@ -1,0 +1,59 @@
+From f01d01d56a57537d468ba6ff45e481ba3fcffc92 Mon Sep 17 00:00:00 2001
+From: Martin Williams <martinr.williams@gmail.com>
+Date: Tue, 30 Mar 2021 16:04:18 +0100
+Subject: [PATCH] driver_wext.c: For Squeezebox Radio - Restrict length of
+ bogus SSID
+
+This patch has been prepared in the context of the Squeezebox Radio
+which uses an Atheros AR6002 wi-fi module.
+
+The Radio is observed to generate "Wireless Event too big (33)"
+kernel messages when wpa_supplicant commands the wi-fi radio to
+disconnect from its AP.
+
+The command that generates the error is SIOCSIWESSID (cmd=0x8B1A).
+
+Investigation shows that these are triggered by wpa_supplicant's WEXT
+driver which sets a randomized bogus SSID following each disconnection,
+with the SSID having length 32 (the maximum length of an SSID). It does
+this by way of an SIOCSIWESSID ioctl call.
+
+It appears that the AR6000/AR6002 driver/firmware will always have
+difficulty with SSIDs of length 32. We do not have the source code
+available, but the driver does appear to anticipate that the provided
+SSID will have been been, perhaps, NULL terminated, yet still only
+occupy 32 bytes.
+
+This change mitigates the issue by restricting the length of the
+randomized bogus SSID to 31. It is of no real consequence, I think, but,
+with a growing number of recent reports of wi-fi difficulties with the
+Radio, these irrelevant error messages can only distract attention from
+determining the root cause of the difficulties.
+---
+ src/drivers/driver_wext.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/drivers/driver_wext.c b/src/drivers/driver_wext.c
+index 4d4a05d0c..331368a64 100644
+--- ../src/drivers/driver_wext.c
++++ ../src/drivers/driver_wext.c
+@@ -1986,10 +1986,14 @@ static void wpa_driver_wext_disconnect(struct wpa_driver_wext_data *drv)
+ 		 * to associate with something even if it does not understand
+ 		 * SIOCSIWMLME commands (or tries to associate automatically
+ 		 * after deauth/disassoc).
++		 * Note: Patched to restrict length of SSID to SSID_MAX_LEN - 1
++		 * (31) to cater for AR6000/AR6002 driver/firmware in use on
++		 * the Squeezebox Radio. This driver/firmware does not appear
++		 * to respond well to SSIDs with length SSID_MAX_LEN (32).
+ 		 */
+-		for (i = 0; i < SSID_MAX_LEN; i++)
++		for (i = 0; i < (SSID_MAX_LEN - 1); i++)
+ 			ssid[i] = rand() & 0xFF;
+-		if (wpa_driver_wext_set_ssid(drv, ssid, SSID_MAX_LEN) < 0) {
++		if (wpa_driver_wext_set_ssid(drv, ssid, SSID_MAX_LEN - 1) < 0) {
+ 			wpa_printf(MSG_DEBUG, "WEXT: Failed to set bogus "
+ 				   "SSID to disconnect");
+ 		}
+-- 
+2.30.1
+

--- a/poky/meta-squeezeos/packages/wpa-supplicant/wpa-supplicant_2.9.bb
+++ b/poky/meta-squeezeos/packages/wpa-supplicant/wpa-supplicant_2.9.bb
@@ -5,6 +5,7 @@ LICENSE = "GNU GPL"
 PR = "r0"
 
 SRC_URI = "http://w1.fi/releases/wpa_supplicant-${PV}.tar.gz \
+	   file://bogus-SSID-too-long_2.9.patch;patch=1;pnum=0 \
 	   file://defconfig"
 
 SRC_URI_append_baby = " \


### PR DESCRIPTION
This proposed change eliminates the "Wireless Event too big (33)" kernel messages that are observed on a Squeezebox Radio each time it disconnects from an AP.

I don't think the message is of any significance, and it is also present in the Radio's "stock" firmware. However I think it may be a distraction when users are attempting to debug wi-fi connectivity issues, and there have been a number of reports of those over the last year or two. "Squashing" the message will remove one source of concern.

The issue has been discussed in forum thread "Community Build Radio Firmware". These two posts record some of the investigatory process that has been undertaken:

https://forums.slimdevices.com/showthread.php?111663-Community-Build-Radio-Firmware&p=1016905&viewfull=1#post1016905
https://forums.slimdevices.com/showthread.php?111663-Community-Build-Radio-Firmware&p=1017259&viewfull=1#post1017259

The change applies a patch to `wpa_supplicant` that causes it to reduce the size of a "bogus SSID" that it generates on disconnection to a length of 31 bytes, rather than the full 32 bytes possible. That eliminates the kernel message.

Further detail is provided in the commit message, and in the patch itself.

I have tested this on a Squeezebox Radio, and it appears to operate as intended, with no adverse side effects noted. It would be sensible to trial this on other Radios, in case an unexpectedissue should be revealed. And a second set of eyes applied to the proposed change would be welcome.
