### PR TITLE
Feature/wireless fixes

### DIFF
--- a/poky/meta-squeezeos/packages/wpa-supplicant/files/Revert-wext-Increase-scan-timeout_2.9.patch
+++ b/poky/meta-squeezeos/packages/wpa-supplicant/files/Revert-wext-Increase-scan-timeout_2.9.patch
@@ -1,0 +1,43 @@
+From 68d4523c916a84fed8ebbe7ff9504bd6d6274824 Mon Sep 17 00:00:00 2001
+From: Martin Williams <martinr.williams@gmail.com>
+Date: Sat, 14 Aug 2021 18:02:56 +0100
+Subject: [PATCH] Revert "wext: Increase scan timeout from 5 to 10 seconds"
+
+This change reverts commit 180cdf45a415969b851aab530e9b23606032941a.
+
+That change increased the scan timeout for the following reason:
+
+    Some dualband cards can use more than five seconds to run through
+    a full scan, so increase the timeout to avoid hitting the missing
+    scan completed event workaround.
+
+This has an adverse effect on Squeezeplay's UI, which anticipates that
+results will be available in about 5 seconds or so.
+
+The consequence is that the user will frequently not see any available
+wireless networks when he browses into the "Choose Network" menu, other
+than those that may exist in the wpa_supplicant.conf configuration file.
+
+Why a timeout should be necessary is unknown. It is possible that the
+Atheros driver in use in the 'baby' does not generate "scan completed"
+wireless events.
+---
+ src/drivers/driver_wext.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/drivers/driver_wext.c b/src/drivers/driver_wext.c
+index 4d4a05d0c..59e4e0f85 100644
+--- ../src/drivers/driver_wext.c
++++ ../src/drivers/driver_wext.c
+@@ -1117,7 +1117,7 @@ int wpa_driver_wext_scan(void *priv, struct wpa_driver_scan_params *params)
+ 
+ 	/* Not all drivers generate "scan completed" wireless event, so try to
+ 	 * read results after a timeout. */
+-	timeout = 10;
++	timeout = 5;
+ 	if (drv->scan_complete_events) {
+ 		/*
+ 		 * The driver seems to deliver SIOCGIWSCAN events to notify
+-- 
+2.30.1
+

--- a/poky/meta-squeezeos/packages/wpa-supplicant/files/wifi_disconnect_baby
+++ b/poky/meta-squeezeos/packages/wpa-supplicant/files/wifi_disconnect_baby
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Disconnect the radio from its access point before taking the wireless
+# interface down.
+
+# When a wireless interface is taken down (e.g. during ifdown)
+# wpa_supplicant > v0.7.2 will place the wireless interface
+# into an 'INTERFACE_DISABLED' state. But it does not disconnect
+# the radio from the access point - the connection remains intact.
+
+# When the interface is next brought back up, wpa_supplicant
+# transitions into a 'DISCONNECTED' state, although the pre-existing
+# wireless connection remains active.
+
+# In this state, wpa_supplicant ignores a wpa_cli 'DISCONNECT' command,
+# so we can not disconnect from that pre-existing wireless connection.
+# It remain active.
+
+# This breaks Squeezeplay's network management logic, which relies upon
+# a fully working and timely wpa_cli 'DISCONNECT'. For example, when
+# switching to a new wireless network it is more than likely that the
+# DHCP client will obtain a configuration for the new network from the
+# old, still connected, network. This does't work well.
+
+if [ "$IFACE"x = eth1x ]; then
+	# Kick the DHCP client into releasing the existing lease
+	/bin/kill -usr2 `cat /var/run/udhcpc.$IFACE.pid`
+	# Give it some time ...
+	sleep 1
+	# ... before disconnecting from the AP.
+	/usr/sbin/wpa_cli disconnect
+fi

--- a/poky/meta-squeezeos/packages/wpa-supplicant/wpa-supplicant_2.9.bb
+++ b/poky/meta-squeezeos/packages/wpa-supplicant/wpa-supplicant_2.9.bb
@@ -6,6 +6,7 @@ PR = "r0"
 
 SRC_URI = "http://w1.fi/releases/wpa_supplicant-${PV}.tar.gz \
 	   file://bogus-SSID-too-long_2.9.patch;patch=1;pnum=0 \
+	   file://Revert-wext-Increase-scan-timeout_2.9.patch;patch=1;pnum=0 \
 	   file://defconfig"
 
 SRC_URI_append_baby = " \

--- a/poky/meta-squeezeos/packages/wpa-supplicant/wpa-supplicant_2.9.bb
+++ b/poky/meta-squeezeos/packages/wpa-supplicant/wpa-supplicant_2.9.bb
@@ -10,6 +10,7 @@ SRC_URI = "http://w1.fi/releases/wpa_supplicant-${PV}.tar.gz \
 
 SRC_URI_append_baby = " \
 	file://wifi_interface_up_baby \
+	file://wifi_disconnect_baby \
 	"
 
 S = "${WORKDIR}/wpa_supplicant-${PV}/wpa_supplicant"
@@ -41,6 +42,8 @@ do_install_append_baby() {
 	# network script - ensure interface (eth1) is raised back 'up' after 'ifdown'
 	install -m 0755 -d ${D}${sysconfdir}/network/if-post-down.d
 	install -m 0755 ${WORKDIR}/wifi_interface_up_baby ${D}${sysconfdir}/network/if-post-down.d/wifi_interface_up
+	install -m 0755 -d ${D}${sysconfdir}/network/if-down.d
+	install -m 0755 ${WORKDIR}/wifi_disconnect_baby ${D}${sysconfdir}/network/if-down.d/wifi_disconnect
 }
 
 PACKAGES = "wpa-supplicant-dbg wpa-supplicant"


### PR DESCRIPTION
These two proposed changes addresses a couple of additional issues that arise under `wpa_supplicant v2.9`, on the baby.

**ifdown prevents disconnection from existing AP**

Further to the issue noted in https://github.com/ralph-irving/squeezeos/pull/7, _Wi-fi radio operations require interface to be UP_, I have identified an additional problem that arises when a wireless interface is taken down.

In a nutshell, `wpa_supplicant` will not actually disconnect the radio from its access point when the interface is taken down. When the interface is brought back up, `wpa_supplicant` will transition into a 'DISCONNECTED' state, even though the underlying wireless connection remains undisturbed. And any further attempts at `wpa_cli disconnect` will do nothing - the radio  remains stubbornly connected.

That doesn't matter if we are trying to reconnect to the **same** AP, but it breaks Squeezeplay's network management logic when we are trying to connect to a **new** AP. In this latter case the DHCP configuration for the new AP will be obtained from the pre-existing connection to the old AP, before the radio actually connects to the new AP. This almost certainly results in a broken network. Basically because Squeezeplay's issuance of `wpa_cli disconnect` prior to 'upping' the new network goes unheeded.

This proposed change introduces a `network/if-down.d/wifi_disconnect` script that disconnects the radio from the AP immediately before the interface is taken down. When the interface is next brought back up, the radio will be truly be in the  'DISCONNECTED' state that `wpa_supplicant` assumes, and that Squeezeplay requires before 'upping' the new network.

The installed script appears to operate as expected on the Radio, but confirmation/review welcome.

I have hosted the change within the wpa_supplicant v2.9 package, on the premise that that is where it belongs. And, at present, its action is limited to the 'baby' build.

**Wireless scan timeout is too long for 'baby'** 

Already reported in https://github.com/ralph-irving/squeezeos-squeezeplay/issues/5, section _Wi-fi scan results - Taking much longer to produce_

The reason for this has been identified, a wireless scan time out has been increased from 5 to 10 seconds.  It seems that this does not play well with the Atheros hardware.

This proposed change to `wpa_supplicant` restores the earlier, 5 second, time out. Matters are noticeably improved, although the regular automatic rescan of wireless networks is still required.
