### PR TITLE
Update timezone data

### DIFF
--- a/poky/build/conf/local.conf.sample
+++ b/poky/build/conf/local.conf.sample
@@ -118,9 +118,16 @@ PACKAGE_CLASSES ?= "package_ipk"
 # Use "oabi" for machines with kernels < 2.6.18 on ARM for example.
 # Use "external-MODE" to use the precompiled external toolchains where MODE
 # is the type of external toolchain to use e.g. eabi.
+
+# "external-csl2010q1-modified" is a modified version of the Code Sourcery
+# csl2010q1 tool chain used to build the Community Firmware.
+# Always 'clean' the tool chain before switching to or from it:
+#   bitbake -c clean external-csl-toolchain
+
 #POKYMODE = "external-csl2009q1"
 #POKYMODE = "external-csl2009q3"
-POKYMODE = "external-csl2010q1"
+#POKYMODE = "external-csl2010q1"
+POKYMODE = "external-csl2010q1-modified"
 #POKYMODE = "external-csl2010.09"
 
 # Uncomment this to specify where BitBake should create its temporary files.

--- a/poky/meta-squeezeos/conf/distro/include/poky-external-csl2010q1-modified.inc
+++ b/poky/meta-squeezeos/conf/distro/include/poky-external-csl2010q1-modified.inc
@@ -1,0 +1,22 @@
+#
+# Poky configuration to use a modified external CSL 2010q1 toolchain (ARM EABI)
+# for building the Community Firmware.
+#
+
+TARGET_VENDOR = "-none"
+
+PREFERRED_PROVIDER_linux-libc-headers = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/arm-none-linux-gnueabi-gcc = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/arm-none-linux-gnueabi-gcc-initial = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/arm-none-linux-gnueabi-gcc-intermediate = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/arm-none-linux-gnueabi-binutils = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/arm-none-linux-gnueabi-libc-for-gcc = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/libc = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/libintl = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/libiconv = "external-csl-toolchain"
+PREFERRED_PROVIDER_glibc-thread-db = "external-csl-toolchain"
+PREFERRED_PROVIDER_virtual/linux-libc-headers = "external-csl-toolchain"
+
+PREFERRED_VERSION_external-csl-toolchain = "2010q1-202-modified"
+
+TOOLCHAIN_OPTIONS = " --sysroot=${STAGING_DIR_HOST}"

--- a/poky/meta-squeezeos/packages/meta/external-csl-toolchain_2010q1-202-modified.bb
+++ b/poky/meta-squeezeos/packages/meta/external-csl-toolchain_2010q1-202-modified.bb
@@ -1,0 +1,44 @@
+# This is a modified version of the external tool chain package
+#  'external-csl-toolchain_2010q1-202.bb'.
+# It is used to build the Community Firmware.
+
+# Changes to 2010q1 are:
+#
+# 1) The time zone database '/usr/share/zoneinfo' is now populated by using
+#    recipe 'tzdata-squeezeos'. This allows it to be updated in future. A
+#    run time dependency on 'tzdata-squeezeos' ensures that it will be
+#    populated.
+
+
+PR = "r0"
+
+# Base package
+
+require external-csl-toolchain_2010q1-202.bb
+
+
+# Override SRC_URI, because the base package incorporates a parameterized
+# version number ${PV}, which no longer matches up.
+
+SRC_URI = "https://sourcery.sw.siemens.com/public/gnu_toolchain/arm-none-linux-gnueabi/arm-2010q1-202-arm-none-linux-gnueabi-i686-pc-linux-gnu.tar.bz2 \
+        file://SUPPORTED"
+
+
+# Remove timezone data installed by base package.
+
+do_install_append() {
+        rm -r ${D}/usr/share/zoneinfo
+        rm    ${D}/etc/localtime
+}
+
+
+# Add run time dependency on 'tzdata-squeezeos' to populate
+# '/usr/share/zoneinfo' and create '/etc/localtime' initial link.
+
+RDEPENDS += "tzdata-squeezeos"
+
+
+# Always clean our "automatic" dependency 'tzdata-squeezeos' whenever we
+# clean this package. (Helps to avoid confusion if switching tool chain.)
+
+do_clean[depends] += "tzdata-squeezeos:do_clean"

--- a/poky/meta-squeezeos/packages/tzdata/files/required_tzones.txt
+++ b/poky/meta-squeezeos/packages/tzdata/files/required_tzones.txt
@@ -1,0 +1,114 @@
+# -------------------------------------------------------------------------
+# Time zone check file.
+# -------------------------------------------------------------------------
+
+# Ensure that all these timezones are present in the OS to ensure maximum
+# interoperablity.
+
+# Blank lines and comments ('#') are ignored, all others identify timezone
+# data files that are expected to be present.
+# The first data field is the name of the timezone, additional comments
+# may be appended to the line if desired.
+
+# -------------------------------------------------------------------------
+# These are the timezones that are used by the "stock" Squeezeplay and all
+# versions up to release 8.0.1r16855.
+# -------------------------------------------------------------------------
+
+Africa/Cairo
+Africa/Casablanca
+Africa/Johannesburg
+Africa/Lagos
+Africa/Nairobi
+America/Anchorage
+America/Bogota
+America/Buenos_Aires
+America/Caracas
+America/Chicago
+America/Chihuahua
+America/Denver
+America/Godthab
+America/Halifax
+America/Indianapolis
+America/Los_Angeles
+America/Mexico_City
+America/New_York
+America/Noronha
+America/Phoenix
+America/Regina
+America/Santiago
+America/Sao_Paulo
+America/St_Johns
+Asia/Baghdad
+Asia/Bangkok
+Asia/Calcutta
+Asia/Colombo
+Asia/Dhaka
+Asia/Hong_Kong
+Asia/Irkutsk
+Asia/Jerusalem
+Asia/Kabul
+Asia/Karachi
+Asia/Katmandu
+Asia/Krasnoyarsk
+Asia/Magadan
+Asia/Muscat
+Asia/Novosibirsk
+Asia/Rangoon
+Asia/Riyadh
+Asia/Seoul
+Asia/Singapore
+Asia/Taipei
+Asia/Tbilisi
+Asia/Tehran
+Asia/Tokyo
+Asia/Vladivostok
+Asia/Yakutsk
+Asia/Yekaterinburg
+Atlantic/Azores
+Atlantic/Cape_Verde
+Australia/Adelaide
+Australia/Brisbane
+Australia/Darwin
+Australia/Hobart
+Australia/Perth
+Australia/Sydney
+Europe/Belgrade
+Europe/Berlin
+Europe/Bucharest
+Europe/Helsinki
+Europe/Istanbul
+Europe/London
+Europe/Moscow
+Europe/Paris
+Europe/Sarajevo
+Pacific/Apia
+Pacific/Auckland
+Pacific/Fiji
+Pacific/Guam
+Pacific/Honolulu
+Pacific/Norfolk
+Pacific/Pitcairn
+Pacific/Tongatapu
+
+Factory                         The initial system default
+
+# -------------------------------------------------------------------------
+# These are the additional timezones used by a "2021e" based Squeezeplay
+# that are not used by any previous Squeezeplay version.
+# -------------------------------------------------------------------------
+
+Africa/Monrovia                 [1]
+America/Argentina/Buenos_Aires  [1] America/Buenos_Aires links to this
+America/Indiana/Indianapolis    [1] America/Indianapolis links to this
+America/Nuuk                    [2] America/Godthab links to this
+Asia/Almaty                     [1]
+Asia/Dubai                      [1] Asia/Muscat links to this
+Asia/Kathmandu                  [1] Asia/Katmandu
+Asia/Kolkata                    [1] Asia/Calcutta links to this
+Asia/Yangon                     [2] Asia/Rangoon links to this
+Pacific/Majuro                  [1]
+Pacific/Pago_Pago               [1]
+
+# [1] Timezone data file present in original SqueezeOS
+# [2] Timezone data file not present in original SqueezeOS

--- a/poky/meta-squeezeos/packages/tzdata/tzdata-squeezeos_2021e.bb
+++ b/poky/meta-squeezeos/packages/tzdata/tzdata-squeezeos_2021e.bb
@@ -1,0 +1,124 @@
+DESCRIPTION = "Timezone data for SqueezeOS"
+SECTION  = "base"
+PRIORITY = "optional"
+
+# This recipe is a customized version of 'tzdata', which builds the timezone
+# database '/usr/share/zoneinfo'. It replaces the timezone database provided
+# by the CSL tool chain.
+
+# The recipe 'tzdata' cannot be used 'as is' for this purpose, because it does
+# not compile suitable timezone files for this older 32 bit OS.
+
+# It is intended to be automatically invoked by recipe
+#  'external-csl-toolchain_2010q1-202-modified.bb', which is a modified
+# version of the CSL tool chain that suppresses timezone database generation.
+
+PR = "r0"
+
+# Ideally, the version of 'tzcode-native' should match the version of this
+# recipe, but Bitbake does not provide for versioned dependencies.
+# The 'do_compile' function will check that the version of the timezone
+# compiler 'zic' does, indeed, match.
+DEPENDS  = "tzcode-native"
+
+# This package will replace any packages provided by the 'tzdata' recipe.
+RCONFLICTS = "tzdata tzdata-africa tzdata-americas tzdata-antarctica \
+              tzdata-arctic tzdata-asia tzdata-atlantic \
+              tzdata-australia tzdata-europe tzdata-misc \
+              tzdata-pacific tzdata-posix tzdata-right"
+
+# And any earlier packages. The 'tzdata' recipe identifies this earlier package.
+RCONFLICTS += "timezones timezone-africa timezone-america timezone-antarctica \
+               timezone-arctic timezone-asia timezone-atlantic \
+               timezone-australia timezone-europe timezone-indian \
+               timezone-iso3166.tab timezone-pacific timezone-zone.tab"
+
+SRC_URI = "https://data.iana.org/time-zones/releases/tzdata${PV}.tar.gz \
+           file://required_tzones.txt"
+
+
+S = "${WORKDIR}"
+
+# Available time zone data files are:
+#   africa antarctica asia australasia europe northamerica
+#   southamerica factory etcetera backward
+
+# Time zone data files that we will build:
+TZONES = "africa antarctica asia australasia europe northamerica \
+          southamerica factory etcetera backward"
+
+# Where we will place the compiled files, i.e. ${S}/usr/share/zoneinfo.
+ZONEINFO_TGT = ${S}${datadir}/zoneinfo
+
+do_compile () {
+
+        #
+        # Create the timezone (tzif) files.
+        #
+
+        # Check zic version - looks like 'zic (tzcode) 2021e'
+        ZICVER=$(${STAGING_BINDIR_NATIVE}/zic --version)
+        case "$ZICVER" in
+          *${PV}*) ;;
+          *) oefatal "Package tzcode provides an unexpected zic version: $ZICVER. Version ${PV} expected.";;
+        esac
+
+        for zone in ${TZONES}; do
+            # Need the '-b fat' option to generate tzif files compatible with
+            # older 32 bit systems.
+            ${STAGING_BINDIR_NATIVE}/zic -d ${ZONEINFO_TGT} -b fat \
+              -L /dev/null ${S}/${zone};
+            # If 'posix' & 'right' zoneinfo is needed, generate as follows:
+            # ${STAGING_BINDIR_NATIVE}/zic -d ${ZONEINFO_TGT}/posix -b fat \
+            #   -L /dev/null ${S}/${zone};
+            # ${STAGING_BINDIR_NATIVE}/zic -d ${ZONEINFO_TGT}/right -b fat \
+            #   -L ${S}/leapseconds ${S}/${zone};
+        done
+
+        #
+        # Check that all required timezone files are present.
+        #
+
+        # Sanity check - grep errors will be lost in next pipeline
+        [ -f ${WORKDIR}/required_tzones.txt -a -r ${WORKDIR}/required_tzones.txt ] || \
+          oefatal "File 'required_tzones.txt' cannot be read."
+        # strip blank lines/comment lines first
+        grep -v '^[[:blank:]]*\(#\|$\)' ${WORKDIR}/required_tzones.txt | \
+        while read name comment; do \
+            [ -f ${ZONEINFO_TGT}/$name ] || \
+              oefatal "Required timezone '$name' not present. Comment: $comment"
+        done
+
+        # If, for some reason, we have not generated a required
+        # 'old-name -> new-name' timezone link, we could have made it and/or
+        # checked it, as follows:
+        #   old_name="Asia/Rangoon"
+        #   new_name="Asia/Yangon"
+        #   [ -f ${ZONEINFO_TGT}/$old_name ]  || \
+        #     ln ${ZONEINFO_TGT}/$new_name ${ZONEINFO_TGT}/$old_name ;
+
+        # Generate a posixrules file (substitute for zic -p option)
+        # But not needed by SqueezeOS
+        #ln ${ZONEINFO_TGT}/America/New_York ${ZONEINFO_TGT}/posixrules
+}
+
+do_install () {
+        # make target directories available
+        install -d -m 0755 ${D}${datadir}/zoneinfo
+        install -d -m 0755 ${D}${sysconfdir}
+
+        # copy over generated zoneinfo directory - preserving permissions
+        cp -pPR ${ZONEINFO_TGT} ${D}${datadir}
+
+        # supplementary files
+        # But not needed by SqueezeOS
+        #install -m 0644 ${S}/iso3166.tab  ${D}${datadir}/zoneinfo
+        #install -m 0644 ${S}/zone.tab     ${D}${datadir}/zoneinfo
+        #install -m 0644 ${S}/zone1970.tab ${D}${datadir}/zoneinfo
+
+        # create /etc/localtime link
+        ln -s ../usr/share/zoneinfo/Factory ${D}/${sysconfdir}/localtime
+}
+
+
+FILES_${PN} = "${datadir}/zoneinfo ${sysconfdir}"


### PR DESCRIPTION
This PR should be considered draft at this point, although it appears to be working as intended locally. However it would benefit from critical review.

It has been prepared in follow up to the issue _Updating timezone data #16_, and offers a concrete implementation in a form that can be more easily reviewed.

The basic outline is:

A new, bespoke, timezone data recipe that has been customized for SqueezeOS. The existing `tzdata` recipe cannot be used because it does not compile suitable timezone files for this older 32 bit OS.

A customized toolchain, whose purpose is to suppress the out of date timezone data provided by the existing toolchain, and call upon the new timezone data recipe to provide it.

Squeezeplay will also require modification, a further PR will be raised against the squeezeos-squeezeplay repository.
