### PR TITLE
additional ar6000 wifi stability improvement

### DIFF
--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan
@@ -25,9 +25,11 @@ case "$1" in
 	    exit -1
 	fi
 
-	/lib/atheros/wmiconfig -eth1 --filter=all
-
 	# act on settings from /etc/wlan.conf
+	if [ "${filterall}" == "on" ]; then
+		/lib/atheros/wmiconfig -eth1 --filter=all
+	fi
+
 	if [ "${gonly}" == "on" ]; then
 		/lib/atheros/wmiconfig --wmode gonly	
 	fi


### PR DESCRIPTION
update /etc/init.d/wlan to disable by default the call to wmiconfig --filter; it can be re-enabled by setting filterall=on in /etc/wlan.conf

       if [ "${filterall}" == "on" ]; then
               /lib/atheros/wmiconfig -eth1 --filter=all
       fi