### PR TITLE
SB Radio - WiFi Robustness applet - Add Truncate Beacons display count, and 'power --maxperf' options

### DIFF
--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
@@ -31,6 +31,7 @@ function settingsShow(self, menuItem)
 	local gonlyEnabled = _fileMatch("/etc/wlan.conf", "^gonly=on")
 	local arpwatchEnabled = _fileMatch("/etc/wlan.conf", "^arpwatch=on")
 	local filterallEnabled = _fileMatch("/etc/wlan.conf", "^filterall=on")
+	local maxperfEnabled = _fileMatch("/etc/wlan.conf", "^maxperf=on")
 
 	local window = Window("help_list", menuItem.text, 'settingstitle')
 	local menu = SimpleMenu("menu", {
@@ -120,6 +121,40 @@ function settingsShow(self, menuItem)
 			end
 			local text   = Textarea('help_text', self:string("TRUNCATED_BCN_TEXT", tostring(truncation_cnt)))
 			window:addWidget(text)
+			self:tieAndShowWindow(window)
+		end
+	})
+
+	-- Enable setting 'wmiconfig -eth1 --power maxperf'
+	menu:addItem ({
+		text     = self:string("MAXPERF_ENABLE"),
+		sound    = "WINDOWSHOW",
+		callback = function (event, menuItem)
+			local window = Window("text_list", self:string("MAXPERF_ENABLE"))
+			window:setAllowScreensaver(false)
+			local menu =  SimpleMenu("menu")
+			menu:setHeaderWidget(Textarea("help_text", self:string("MAXPERF_HOWTO")))
+			local checkb = Checkbox("checkbox",
+					function(_, isSelected)
+						settingsChanged = true
+						if isSelected then
+							log:warn("wlan.conf setting maxperf=on")
+							_fileSub("/etc/wlan.conf", "^maxperf=.*$", "maxperf=on")
+							maxperfEnabled = true
+						else
+							log:warn("wlan.conf setting maxperf=off")
+							_fileSub("/etc/wlan.conf", "^maxperf=.*$", "maxperf=off")
+							maxperfEnabled = false
+						end
+					end,
+					maxperfEnabled
+				)
+			menu:addItem({
+				text  = self:string("MAXPERF_ENABLE"),
+				style = 'item_choice',
+				check = checkb,
+			})
+			window:addWidget(menu)
 			self:tieAndShowWindow(window)
 		end
 	})

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
@@ -103,7 +103,28 @@ function settingsShow(self, menuItem)
 				})
 
 	window:addWidget(menu)
-	
+
+
+	-- Displays the number of truncated beacons logged.
+	menu:addItem ({
+		text     = self:string("TRUNCATED_BCN_TITLE"),
+		sound    = "WINDOWSHOW",
+		callback = function (event, menuItem)
+			local window = Window("text_list", self:string("TRUNCATED_BCN_TITLE"))
+			window:setAllowScreensaver(false)
+			local grepRes = io.popen("/bin/grep -ci \'AR6000\\s\\+Truncated\' /var/log/messages")
+			local truncation_cnt = grepRes:read("*line")
+			grepRes:close()
+			if not truncation_cnt then
+				truncation_cnt = "<Read error>"
+			end
+			local text   = Textarea('help_text', self:string("TRUNCATED_BCN_TEXT", tostring(truncation_cnt)))
+			window:addWidget(text)
+			self:tieAndShowWindow(window)
+		end
+	})
+
+
 	window:addListener(EVENT_WINDOW_INACTIVE, 
 		function()
 			if settingsChanged then

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
@@ -22,3 +22,9 @@ FILTERALL_ENABLE
 
 FILTERALL_HOWTO
 	EN	Enabling all BSS filters restores this default option set in the original firmware
+
+TRUNCATED_BCN_TITLE
+	EN	Truncated beacon count
+
+TRUNCATED_BCN_TEXT
+	EN	There are %s occurrences of 'truncated' WiFi beacons noted in the system log.\n\nThese are known to cause WiFi problems, although a handful seems to be tolerable.

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
@@ -28,3 +28,9 @@ TRUNCATED_BCN_TITLE
 
 TRUNCATED_BCN_TEXT
 	EN	There are %s occurrences of 'truncated' WiFi beacons noted in the system log.\n\nThese are known to cause WiFi problems, although a handful seems to be tolerable.
+
+MAXPERF_ENABLE
+	EN	Enable 'Power Maxperf'
+
+MAXPERF_HOWTO
+	EN	Setting 'Power Maxperf' restores this default option set in the original firmware. It may trigger WiFi issues, so set this only if investigating WiFi behaviour.

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan
@@ -55,6 +55,10 @@ case "$1" in
 		${WORKAREA}/watch-arp.sh
 	fi
 
+	if [ "${maxperf}" == "on" ]; then
+		${WORKAREA}/wmiconfig -eth1 --power maxperf
+	fi
+
 	# todo region codes?
 	sleep 1;
 

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan.conf
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan.conf
@@ -1,3 +1,4 @@
 arpwatch=off
 filterall=off
 gonly=off
+maxperf=off


### PR DESCRIPTION
These proposed changes add a couple of features to the WiFi robustness applet.

- **Add a display count of "Truncated Beacons" to wifi robustness applet**

  This change adds a simple view of the number of Truncated Beacons detected in the system log.

  It is in follow up to my comment here https://github.com/ralph-irving/squeezeos/pull/26#issuecomment-2773452929, in connection with PR [Log truncated beacons implicated in WiFi issues #26](https://github.com/ralph-irving/squeezeos/pull/26).

  You suggested "not to bother" with doing this, and you may well be right ! But reasonably easily done, so  I am offering up the option for consideration.

- **Add 'power --maxperf' setting to wifi robustness applet**

  This change allows the old option set in the original firmware wlan script to be re-enabled. It's only good for investigative purposes.

  It may be simply unwise to offer this option, as it could end up generating more user questions than is warranted.
  So definitely optional, and if you wish to drop it, that's fine by me.


Both changes have been tested on my SB Radio, and appear to work as expected.
