### PR TITLE
WiFi Robustness Applet - Bug fixes

### DIFF
--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
@@ -125,7 +125,7 @@ function settingsShow(self, menuItem)
 		end
 	})
 
-	-- Enable setting 'wmiconfig -eth1 --power maxperf'
+	-- Enable setting 'wmiconfig -i eth1 --power maxperf'
 	menu:addItem ({
 		text     = self:string("MAXPERF_ENABLE"),
 		sound    = "WINDOWSHOW",
@@ -159,8 +159,8 @@ function settingsShow(self, menuItem)
 		end
 	})
 
-
-	window:addListener(EVENT_WINDOW_INACTIVE, 
+	-- Restart the WiFi when the menu is exited
+	window:addListener(EVENT_WINDOW_POP,
 		function()
 			if settingsChanged then
 				os.execute("/lib/atheros/restart-wifi.sh &")
@@ -175,6 +175,7 @@ function settingsShow(self, menuItem)
 	self:tieAndShowWindow(window)
 	return window
 end
+
 function _addHelpInfo(self)
 	self.howto = Textarea("help_text", self:string("GONLY_HOWTO"))
 	self.menu:setHeaderWidget(self.howto)
@@ -202,24 +203,29 @@ function _fileMatch(file, pattern)
 end
 
 function _fileSub(file, pattern, repl)
-        local data = ""
-        local match = false
+	local data = ""
+	local match = false
 
-        local fi = io.open(file, "r")
-        for line in fi:lines() do
-        	if string.match(line, pattern) then
-        		match = true
-                	line = string.gsub(line, pattern, repl)
-                end
-                data = data .. line .. "\n"
-        end
-        -- if we haven't found a match to replace, add to end of file
-        if match == false then
-        	data = data .. repl .. "\n"
-        end
-        fi:close()
-
-        System:atomicWrite(file, data)
+	local fi, errmsg = io.open(file, "r")
+	if fi ~= nil then
+		for line in fi:lines() do
+			if string.match(line, pattern) then
+				match = true
+				line = string.gsub(line, pattern, repl)
+			end
+			data = data .. line .. "\n"
+		end
+		fi:close()
+	else
+		-- user deleted file ?
+		-- we will create one anyway, with the current setting
+		log:warn("Error reading ", file, " : ", errmsg)
+	end
+	-- if we haven't found a match to replace, add to end of file
+	if match == false then
+		data = data .. repl .. "\n"
+	end
+	System:atomicWrite(file, data)
 end
 
 --[[

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan
@@ -44,11 +44,11 @@ case "$1" in
 
 	# act on settings from /etc/wlan.conf
 	if [ "${filterall}" == "on" ]; then
-		${WORKAREA}/wmiconfig -eth1 --filter=all
+		${WORKAREA}/wmiconfig -i eth1 --filter=all
 	fi
 
 	if [ "${gonly}" == "on" ]; then
-		${WORKAREA}/wmiconfig --wmode gonly
+		${WORKAREA}/wmiconfig -i eth1 --wmode gonly
 	fi
 
 	if [ "${arpwatch}" == "on" ]; then
@@ -56,7 +56,7 @@ case "$1" in
 	fi
 
 	if [ "${maxperf}" == "on" ]; then
-		${WORKAREA}/wmiconfig -eth1 --power maxperf
+		${WORKAREA}/wmiconfig -i eth1 --power maxperf
 	fi
 
 	# todo region codes?


### PR DESCRIPTION
This proposed change fixes three matters: 

In commit #27 we introduced some additional options to the Wifi Robustness applet. A small change is needed to ensure that a WiFi restart is not triggered if/when these menu items are taken. That would be too early, we should not restart WiFi until the user exits the applet.

The applet is not resilient to the absence of the `wlan.conf` configuration file. This would not happen under normal circumstances because the firmware already supplies one. But it could happen, and in this circumstance the applet will simply fail to record the user's choice. This change ensures that an attempt will always be made to generate the `wlan.conf` file.

As pointed out recently in the user forums, the calls to `wmiconfig` in the `wlan` start up script are incorrectly formatted. That has not been a problem, because the calls made have succeeded anyway. This change corrects matters.
