### PR TITLE
Baby wifi/wifi robustness3

### DIFF
--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
@@ -36,77 +36,112 @@ function settingsShow(self, menuItem)
 	local maxperfEnabled   = _fileMatch(confFile, "^maxperf=on")
 
 	local window = Window("help_list", menuItem.text, 'settingstitle')
-	local menu = SimpleMenu("menu", {
-					{
-						text = self:string("ARPWATCH_ENABLE"),
-						style = 'item_choice',
-						check = Checkbox("checkbox",
-								function(_, isSelected)
-									settingsChanged = true
-									if isSelected then
-										log:warn("wlan.conf setting arpwatch=on");
-										_fileSub(confFile, "^arpwatch=.*$", "arpwatch=on")
-									else
-										log:warn("wlan.conf setting arpwatch=off");
-										_fileSub(confFile, "^arpwatch=.*$", "arpwatch=off")
-									end
-								end,
-								arpwatchEnabled
-							),
-						focusGained = function(event)
-							self.howto = Textarea("help_text", self:string("ARPWATCH_HOWTO"))
-							self.menu:setHeaderWidget(self.howto)
-							self.menu:reLayout()
-						end
-					},
-					{
-						text = self:string("GONLY_ENABLE"),
-						style = 'item_choice',
-						check = Checkbox("checkbox",
-								function(_, isSelected)
-									settingsChanged = true
-									if isSelected then
-										log:warn("wlan.conf setting gonly=on");
-										_fileSub(confFile, "^gonly=.*$", "gonly=on")
-									else
-										log:warn("wlan.conf setting gonly=off");
-										_fileSub(confFile, "^gonly=.*$", "gonly=off")
-									end
-								end,
-								gonlyEnabled
-							),
-						focusGained = function(event)
-							self.howto = Textarea("help_text", self:string("GONLY_HOWTO"))
-							self.menu:setHeaderWidget(self.howto)
-							self.menu:reLayout()
-						end
-					},
-					{
-						text = self:string("FILTERALL_ENABLE"),
-						style = 'item_choice',
-						check = Checkbox("checkbox",
-								function(_, isSelected)
-									settingsChanged = true
-									if isSelected then
-										log:warn("wlan.conf setting filterall=on");
-										_fileSub(confFile, "^filterall=.*$", "filterall=on")
-									else
-										log:warn("wlan.conf setting filterall=off");
-										_fileSub(confFile, "^filterall=.*$", "filterall=off")
-									end
-								end,
-								filterallEnabled
-							),
-						focusGained = function(event)
-							self.howto = Textarea("help_text", self:string("FILTERALL_HOWTO"))
-							self.menu:setHeaderWidget(self.howto)
-							self.menu:reLayout()
-						end
-					},
-				})
+	window:setAllowScreensaver(false)
 
-	window:addWidget(menu)
+	local menu = SimpleMenu("menu")
+	menu:setHeaderWidget(Textarea("help_text", self:string("WIFI_ROBUSTNESS_HELP")))
 
+	-- Activate ARP watch - watch-arp.sh
+	menu:addItem ({
+		text     = self:string("ARPWATCH_ENABLE"),
+		sound    = "WINDOWSHOW",
+		callback = function (event, menuItem)
+			local window = Window("text_list", menuItem.text)
+			window:setAllowScreensaver(false)
+			local menu = SimpleMenu("menu")
+			menu:setHeaderWidget(Textarea("help_text", self:string("ARPWATCH_HOWTO")))
+			local checkb = Checkbox("checkbox",
+					function(_, isSelected)
+						settingsChanged = true
+						if isSelected then
+							log:info("wlan.conf setting arpwatch=on");
+							_fileSub(confFile, "^arpwatch=.*$", "arpwatch=on")
+							arpwatchEnabled = true
+						else
+							log:info("wlan.conf setting arpwatch=off");
+							_fileSub(confFile, "^arpwatch=.*$", "arpwatch=off")
+							arpwatchEnabled = false
+						end
+					end,
+					arpwatchEnabled
+				)
+			menu:addItem({
+				text  = menuItem.text,
+				style = 'item_choice',
+				check = checkb,
+			})
+			window:addWidget(menu)
+			self:tieAndShowWindow(window)
+		end
+	})
+
+	-- Enable setting 'wmiconfig -i eth1 --wmode gonly'
+	menu:addItem ({
+		text     = self:string("GONLY_ENABLE"),
+		sound    = "WINDOWSHOW",
+		callback = function (event, menuItem)
+			local window = Window("text_list", menuItem.text)
+			window:setAllowScreensaver(false)
+			local menu = SimpleMenu("menu")
+			menu:setHeaderWidget(Textarea("help_text", self:string("GONLY_HOWTO")))
+			local checkb = Checkbox("checkbox",
+					function(_, isSelected)
+						settingsChanged = true
+						if isSelected then
+							log:info("wlan.conf setting gonly=on");
+							_fileSub(confFile, "^gonly=.*$", "gonly=on")
+							gonlyEnabled = true
+						else
+							log:info("wlan.conf setting gonly=off");
+							_fileSub(confFile, "^gonly=.*$", "gonly=off")
+							gonlyEnabled = false
+						end
+					end,
+					gonlyEnabled
+				)
+			menu:addItem({
+				text  = menuItem.text,
+				style = 'item_choice',
+				check = checkb,
+			})
+			window:addWidget(menu)
+			self:tieAndShowWindow(window)
+		end
+	})
+
+	-- Enable setting 'wmiconfig -i eth1 --filter=all'
+	menu:addItem ({
+		text     = self:string("FILTERALL_ENABLE"),
+		sound    = "WINDOWSHOW",
+		callback = function (event, menuItem)
+			local window = Window("text_list", menuItem.text)
+			window:setAllowScreensaver(false)
+			local menu = SimpleMenu("menu")
+			menu:setHeaderWidget(Textarea("help_text", self:string("FILTERALL_HOWTO")))
+			local checkb = Checkbox("checkbox",
+					function(_, isSelected)
+						settingsChanged = true
+						if isSelected then
+							log:info("wlan.conf setting filterall=on")
+							_fileSub(confFile, "^filterall=.*$", "filterall=on")
+							filterallEnabled = true
+						else
+							log:info("wlan.conf setting filterall=off")
+							_fileSub(confFile, "^filterall=.*$", "filterall=off")
+							filterallEnabled = false
+						end
+					end,
+					filterallEnabled
+				)
+			menu:addItem({
+				text  = menuItem.text,
+				style = 'item_choice',
+				check = checkb,
+			})
+			window:addWidget(menu)
+			self:tieAndShowWindow(window)
+		end
+	})
 
 	-- Displays the number of truncated beacons logged.
 	menu:addItem ({
@@ -161,6 +196,8 @@ function settingsShow(self, menuItem)
 		end
 	})
 
+	window:addWidget(menu)
+
 	-- Restart the WiFi when the menu is exited
 	window:addListener(EVENT_WINDOW_POP,
 		function()
@@ -172,18 +209,10 @@ function settingsShow(self, menuItem)
 	)
 
 	self.window = window
-	self.menu = menu
-	self:_addHelpInfo()
+	self.menu   = menu
 
 	self:tieAndShowWindow(window)
 	return window
-end
-
-function _addHelpInfo(self)
-	self.howto = Textarea("help_text", self:string("GONLY_HOWTO"))
-	self.menu:setHeaderWidget(self.howto)
-
-	self.window:focusWidget(self.menu)
 end
 
 function _fileMatch(file, pattern)

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
@@ -26,12 +26,14 @@ local jnt                    = jnt
 module(..., Framework.constants)
 oo.class(_M, Applet)
 
+local confFile = "/etc/wlan.conf"
+
 function settingsShow(self, menuItem)
-	local settingsChanged = false
-	local gonlyEnabled = _fileMatch("/etc/wlan.conf", "^gonly=on")
-	local arpwatchEnabled = _fileMatch("/etc/wlan.conf", "^arpwatch=on")
-	local filterallEnabled = _fileMatch("/etc/wlan.conf", "^filterall=on")
-	local maxperfEnabled = _fileMatch("/etc/wlan.conf", "^maxperf=on")
+	local settingsChanged  = false
+	local gonlyEnabled     = _fileMatch(confFile, "^gonly=on")
+	local arpwatchEnabled  = _fileMatch(confFile, "^arpwatch=on")
+	local filterallEnabled = _fileMatch(confFile, "^filterall=on")
+	local maxperfEnabled   = _fileMatch(confFile, "^maxperf=on")
 
 	local window = Window("help_list", menuItem.text, 'settingstitle')
 	local menu = SimpleMenu("menu", {
@@ -43,10 +45,10 @@ function settingsShow(self, menuItem)
 									settingsChanged = true
 									if isSelected then
 										log:warn("wlan.conf setting arpwatch=on");
-										_fileSub("/etc/wlan.conf", "^arpwatch=.*$", "arpwatch=on")  
+										_fileSub(confFile, "^arpwatch=.*$", "arpwatch=on")
 									else
 										log:warn("wlan.conf setting arpwatch=off");
-										_fileSub("/etc/wlan.conf", "^arpwatch=.*$", "arpwatch=off")
+										_fileSub(confFile, "^arpwatch=.*$", "arpwatch=off")
 									end
 								end,
 								arpwatchEnabled
@@ -65,10 +67,10 @@ function settingsShow(self, menuItem)
 									settingsChanged = true
 									if isSelected then
 										log:warn("wlan.conf setting gonly=on");
-										_fileSub("/etc/wlan.conf", "^gonly=.*$", "gonly=on")  
+										_fileSub(confFile, "^gonly=.*$", "gonly=on")
 									else
 										log:warn("wlan.conf setting gonly=off");
-										_fileSub("/etc/wlan.conf", "^gonly=.*$", "gonly=off")
+										_fileSub(confFile, "^gonly=.*$", "gonly=off")
 									end
 								end,
 								gonlyEnabled
@@ -87,10 +89,10 @@ function settingsShow(self, menuItem)
 									settingsChanged = true
 									if isSelected then
 										log:warn("wlan.conf setting filterall=on");
-										_fileSub("/etc/wlan.conf", "^filterall=.*$", "filterall=on")  
+										_fileSub(confFile, "^filterall=.*$", "filterall=on")
 									else
 										log:warn("wlan.conf setting filterall=off");
-										_fileSub("/etc/wlan.conf", "^filterall=.*$", "filterall=off")
+										_fileSub(confFile, "^filterall=.*$", "filterall=off")
 									end
 								end,
 								filterallEnabled
@@ -111,7 +113,7 @@ function settingsShow(self, menuItem)
 		text     = self:string("TRUNCATED_BCN_TITLE"),
 		sound    = "WINDOWSHOW",
 		callback = function (event, menuItem)
-			local window = Window("text_list", self:string("TRUNCATED_BCN_TITLE"))
+			local window = Window("text_list", menuItem.text)
 			window:setAllowScreensaver(false)
 			local grepRes = io.popen("/bin/grep -ci \'AR6000\\s\\+Truncated\' /var/log/messages")
 			local truncation_cnt = grepRes:read("*line")
@@ -119,7 +121,7 @@ function settingsShow(self, menuItem)
 			if not truncation_cnt then
 				truncation_cnt = "<Read error>"
 			end
-			local text   = Textarea('help_text', self:string("TRUNCATED_BCN_TEXT", tostring(truncation_cnt)))
+			local text = Textarea('help_text', self:string("TRUNCATED_BCN_TEXT", tostring(truncation_cnt)))
 			window:addWidget(text)
 			self:tieAndShowWindow(window)
 		end
@@ -130,27 +132,27 @@ function settingsShow(self, menuItem)
 		text     = self:string("MAXPERF_ENABLE"),
 		sound    = "WINDOWSHOW",
 		callback = function (event, menuItem)
-			local window = Window("text_list", self:string("MAXPERF_ENABLE"))
+			local window = Window("text_list", menuItem.text)
 			window:setAllowScreensaver(false)
-			local menu =  SimpleMenu("menu")
+			local menu = SimpleMenu("menu")
 			menu:setHeaderWidget(Textarea("help_text", self:string("MAXPERF_HOWTO")))
 			local checkb = Checkbox("checkbox",
 					function(_, isSelected)
 						settingsChanged = true
 						if isSelected then
-							log:warn("wlan.conf setting maxperf=on")
-							_fileSub("/etc/wlan.conf", "^maxperf=.*$", "maxperf=on")
+							log:info("wlan.conf setting maxperf=on")
+							_fileSub(confFile, "^maxperf=.*$", "maxperf=on")
 							maxperfEnabled = true
 						else
-							log:warn("wlan.conf setting maxperf=off")
-							_fileSub("/etc/wlan.conf", "^maxperf=.*$", "maxperf=off")
+							log:info("wlan.conf setting maxperf=off")
+							_fileSub(confFile, "^maxperf=.*$", "maxperf=off")
 							maxperfEnabled = false
 						end
 					end,
 					maxperfEnabled
 				)
 			menu:addItem({
-				text  = self:string("MAXPERF_ENABLE"),
+				text  = menuItem.text,
 				style = 'item_choice',
 				check = checkb,
 			})
@@ -163,10 +165,11 @@ function settingsShow(self, menuItem)
 	window:addListener(EVENT_WINDOW_POP,
 		function()
 			if settingsChanged then
+				log:info("Executing /lib/atheros/restart-wifi.sh")
 				os.execute("/lib/atheros/restart-wifi.sh &")
 			end
 		end
-	)        
+	)
 
 	self.window = window
 	self.menu = menu
@@ -185,7 +188,7 @@ end
 
 function _fileMatch(file, pattern)
 	local fi, err = io.open(file, "r")
-	
+
 	if (err) then 
 		return false
 	end
@@ -195,7 +198,6 @@ function _fileMatch(file, pattern)
 			fi:close()
 			return true
 		end
-
 	end
 	fi:close()
 

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/SetupWifiRobustnessApplet.lua
@@ -11,6 +11,7 @@ local string                 = require("string")
 local Applet                 = require("jive.Applet")
 local System                 = require("jive.System")
 local Checkbox               = require("jive.ui.Checkbox")
+local Choice                 = require("jive.ui.Choice")
 local Framework              = require("jive.ui.Framework")
 local Icon                   = require("jive.ui.Icon")
 local Label                  = require("jive.ui.Label")
@@ -31,6 +32,7 @@ local confFile = "/etc/wlan.conf"
 function settingsShow(self, menuItem)
 	local settingsChanged  = false
 	local gonlyEnabled     = _fileMatch(confFile, "^gonly=on")
+	local modegEnabled     = _fileMatch(confFile, "^mode_g=on")
 	local arpwatchEnabled  = _fileMatch(confFile, "^arpwatch=on")
 	local filterallEnabled = _fileMatch(confFile, "^filterall=on")
 	local maxperfEnabled   = _fileMatch(confFile, "^maxperf=on")
@@ -75,34 +77,71 @@ function settingsShow(self, menuItem)
 		end
 	})
 
-	-- Enable setting 'wmiconfig -i eth1 --wmode gonly'
+	-- WiFi mode
+	-- Enable setting one of 'wmiconfig -i eth1 --wmode gonly' or 'wmiconfig -i eth1 --wmode g'
 	menu:addItem ({
-		text     = self:string("GONLY_ENABLE"),
+		text     = self:string("WMODE_SETTINGS"),
 		sound    = "WINDOWSHOW",
 		callback = function (event, menuItem)
 			local window = Window("text_list", menuItem.text)
 			window:setAllowScreensaver(false)
+
+			-- Set up current choice
+			local currentIndex = 1  -- Off
+			if gonlyEnabled then
+				currentIndex = 2
+			elseif modegEnabled then
+				currentIndex = 3
+			end
+
 			local menu = SimpleMenu("menu")
-			menu:setHeaderWidget(Textarea("help_text", self:string("GONLY_HOWTO")))
-			local checkb = Checkbox("checkbox",
-					function(_, isSelected)
+			menu:setHeaderWidget(Textarea("help_text", self:string("WMODE_HOWTO")))
+
+			menu:addItem ({
+				text     = self:string("WMODE_HELP"),
+				sound    = "WINDOWSHOW",
+				callback = function (event, menuItem)
+					local window = Window("text_list", menuItem.text)
+					window:setAllowScreensaver(false)
+					local text = Textarea('help_text', self:string("WMODE_HELPTXT"))
+					window:addWidget(text)
+					self:tieAndShowWindow(window)
+				end
+			})
+
+			local choices = Choice(
+					"choice",
+					{ "Off - recommended", "802.11b disabled", "'mode g'" },
+					function(obj, selectedIndex)
+						log:debug( "Choice updated: ", tostring(selectedIndex), " - ", tostring(obj:getSelected()) )
 						settingsChanged = true
-						if isSelected then
+						if selectedIndex == 2 then
+							gonlyEnabled = true
+							modegEnabled = false
 							log:info("wlan.conf setting gonly=on");
 							_fileSub(confFile, "^gonly=.*$", "gonly=on")
-							gonlyEnabled = true
-						else
-							log:info("wlan.conf setting gonly=off");
-							_fileSub(confFile, "^gonly=.*$", "gonly=off")
+							_fileSub(confFile, "^mode_g=.*$", "mode_g=off")
+						elseif selectedIndex == 3 then
+							modegEnabled = true
 							gonlyEnabled = false
+							log:info("wlan.conf setting mode_g=on");
+							_fileSub(confFile, "^mode_g=.*$", "mode_g=on")
+							_fileSub(confFile, "^gonly=.*$", "gonly=off")
+						else -- default
+							gonlyEnabled = false
+							modegEnabled = false
+							log:info("wlan.conf setting gonly & mode_g=off");
+							_fileSub(confFile, "^gonly=.*$", "gonly=off")
+							_fileSub(confFile, "^mode_g=.*$", "mode_g=off")
 						end
+						currentIndex = selectedIndex
 					end,
-					gonlyEnabled
+					currentIndex
 				)
 			menu:addItem({
-				text  = menuItem.text,
+				text  = self:string("WMODE_LABEL"),
 				style = 'item_choice',
-				check = checkb,
+				check = choices,
 			})
 			window:addWidget(menu)
 			self:tieAndShowWindow(window)

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
@@ -5,6 +5,9 @@
 WIFI_ROBUSTNESS
 	EN	Wifi Robustness Options
 
+WIFI_ROBUSTNESS_HELP
+	EN	The Radio sometimes experiences WiFi connectivity problems. These options may help overcome them.
+
 ARPWATCH_ENABLE
 	EN	Enable ARP watchdog
 

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
@@ -14,11 +14,20 @@ ARPWATCH_ENABLE
 ARPWATCH_HOWTO
 	EN	The ARP watchdog will reset the wifi stack if network connectivity seems to have stopped.
 
-GONLY_ENABLE
-	EN	Disable legacy 802.11b
+WMODE_SETTINGS
+	EN	Wireless mode settings
 
-GONLY_HOWTO
-	EN	Disabling legacy 802.11b can improve wifi stability but may also prevent connecting to some wifi access points.
+WMODE_LABEL
+	EN	WiFi mode
+
+WMODE_HOWTO
+	EN	Customize certain WiFi operating modes. Modes available:\nOff, disable 802.11b, 'mode g'
+
+WMODE_HELP
+	EN	WiFi mode help
+
+WMODE_HELPTXT
+	EN	This setting allows customization of certain WiFi operating modes.\n\nDisabling legacy 802.11b might be required to connect to certain Access Points, and it may improve WiFi stability. But it will also prevent connection with some Access Points.\n\nSome people say that the 'mode g' setting improves stability.\n\n
 
 FILTERALL_ENABLE
 	EN	Enable all BSS filters

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
@@ -9,19 +9,19 @@ ARPWATCH_ENABLE
 	EN	Enable ARP watchdog
 
 ARPWATCH_HOWTO
-	EN	The ARP watchdog will reset the wifi stack if network connectivity seems to have stopped
+	EN	The ARP watchdog will reset the wifi stack if network connectivity seems to have stopped.
 
 GONLY_ENABLE
 	EN	Disable legacy 802.11b
 
 GONLY_HOWTO
-	EN	Disabling legacy 802.11b can improve wifi stability but may also prevent connecting to some wifi access points
+	EN	Disabling legacy 802.11b can improve wifi stability but may also prevent connecting to some wifi access points.
 
 FILTERALL_ENABLE
 	EN	Enable all BSS filters
 
 FILTERALL_HOWTO
-	EN	Enabling all BSS filters restores this default option set in the original firmware
+	EN	Enabling all BSS filters restores this default option set in the original firmware.
 
 TRUNCATED_BCN_TITLE
 	EN	Truncated beacon count

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan
@@ -47,8 +47,11 @@ case "$1" in
 		${WORKAREA}/wmiconfig -i eth1 --filter=all
 	fi
 
+	# --wmode gonly and --wmode g are mutually exclusive
 	if [ "${gonly}" == "on" ]; then
 		${WORKAREA}/wmiconfig -i eth1 --wmode gonly
+	elif [ "${mode_g}" == "on" ]; then
+		${WORKAREA}/wmiconfig -i eth1 --wmode g
 	fi
 
 	if [ "${arpwatch}" == "on" ]; then

--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan.conf
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/wlan.conf
@@ -1,4 +1,5 @@
 arpwatch=off
 filterall=off
 gonly=off
+mode_g=off
 maxperf=off


### PR DESCRIPTION
This proposed change implements the changes to the WiFi Robustness applet tha we discussed earlier. Refer post https://github.com/ralph-irving/squeezeos/pull/29#issuecomment-2905804636.

While it appears to be working as expected, I would still like to do some double checking. But I am in and out for a week or two, with only sporadic availability to pursue, so I thought it might be helpful for you to see where I am at.

The change is put together as three commits:

**Minor refactoring**

Paramaterizing the name of the `wlan.conf` file, with some other minor tidying up.

**Refactor menu structure**

Converts each existing "checkbox" item on the main menu into a separate "push right" menu, and host the checkbox and individual help text/explanation there. It makes for an easier looking display.

**Supplement the existing disable legacy 802.11b ("gonly") option with a "g" option**

Replaces the existing "gonly" checkbox with a multiple choice of "Nothing", "gonly", "g", and provides a separate help window to display a, hopefully, informative explanation to the user.

Accompanied by the relevant change to the `wlan` script, and the default `wlan.conf` file.

I think it could be made a bit more elegant, but I have stayed with the already tested "on|off" style of the existing configuration options. A point to be aware of is that the `--wmode gonly` and `--wmode g` options are mutually exclusive. The `wlan` script does give effect to this, although the main protection is that the applet's logic ensures that only one or other will ever be set.
