### PR TITLE
Firmware upgrade - Don't keep user modified system scripts in /etc/in…

### DIFF
--- a/poky/meta-squeezeos/packages/base-files/files/linuxrc
+++ b/poky/meta-squeezeos/packages/base-files/files/linuxrc
@@ -78,6 +78,8 @@ else
 	then
 		# Remove modified files
 		/bin/echo "SqueezeOS upgraded from $SQUEEZEOS_VERSION"
+		# Note that anything in /etc is kept, so we first move these modified system files aside
+		/usr/bin/find /mnt/storage/ -type f | /bin/grep -f /etc/move-after-upgrade | /usr/bin/xargs -I{} mv {} {}.preupgrade
 		/usr/bin/find /mnt/storage/ -type f | /bin/grep -v -f /etc/keep-after-upgrade | /usr/bin/xargs /bin/rm -f
 
 		# Delete udev cache

--- a/poky/meta-squeezeos/packages/base-files/files/move-after-upgrade
+++ b/poky/meta-squeezeos/packages/base-files/files/move-after-upgrade
@@ -1,0 +1,7 @@
+/etc/init.d/blupdate$
+/etc/init.d/monitor_msp430.sh$
+/etc/init.d/rcS$
+/etc/init.d/squeezeplay$
+/etc/init.d/suspend$
+/etc/init.d/udev$
+/etc/init.d/wlan$

--- a/poky/meta-squeezeos/packages/base-files/squeezeos-base-files_1.0.bb
+++ b/poky/meta-squeezeos/packages/base-files/squeezeos-base-files_1.0.bb
@@ -3,7 +3,7 @@ SECTION = "base"
 PRIORITY = "required"
 LICENSE = "GPL"
 
-PR = "r132"
+PR = "r133"
 
 SRC_URI = " \
 	file://asound.conf \
@@ -24,6 +24,7 @@ SRC_URI = " \
 	file://keep-after-upgrade \
 	file://linuxrc \
 	file://mdev.conf \
+	file://move-after-upgrade \
 	file://motd \
 	file://nsswitch.conf \
 	file://passwd \
@@ -115,6 +116,7 @@ do_install () {
 	install -m 0644 ${WORKDIR}/motd ${D}${sysconfdir}/motd
 	install -m 0644 ${WORKDIR}/mdev.conf ${D}${sysconfdir}/mdev.conf
 	install -m 0644 ${WORKDIR}/keep-after-upgrade ${D}${sysconfdir}/keep-after-upgrade
+	install -m 0644 ${WORKDIR}/move-after-upgrade ${D}${sysconfdir}/move-after-upgrade
 	install -m 0644 ${WORKDIR}/hostname ${D}${sysconfdir}/hostname
 	ln -sf /proc/mounts ${D}${sysconfdir}/mtab
 	install -m 0644 ${WORKDIR}/asound.conf ${D}${sysconfdir}/asound.conf


### PR DESCRIPTION
This proposed change alters SqueezeOS' handling of the system start up scripts contained in `/etc/init.d` when a firmware upgrade is undertaken. The new behaviour moves aside any user modified start up script in `/etc/init.d`, giving it a "preupgrade" suffix. This ensures that the OS's intended "vanilla" script will always be active after an upgrade. 

We discussed this in PR #30, and I have now implemented the change as indicated in this comment: https://github.com/ralph-irving/squeezeos/pull/30#issuecomment-3094777850.

The only scripts that are subjected to this treatment are those that form part of the OS. These are listed in `/etc/move-after-upgrade`. `/etc/init.d/rcS.local`, for example, will remain unchanged.

We do this because the system start up scripts contained within `/etc/init.d` are not really intended to be modified by the user, and may be modified in a way that is not compatible with a new firmware release. (The WiFi start up script is a common target).

The change requires that the busybox implementation of `xargs` supports the "Insert/Replace string" (`-I`) option. This has been effected by way of commit 718344f24c95450746716f473438fecbd464264e, "Backport busybox xargs -I replace string option from v1.23".

The process logic is very similar to that already used by the `keep-after-upgrade` logic. The file `move-after-upgrade` is provided to `grep` to match those files in `/mnt/storage/` (the upper layer of the Union FS) that should be moved aside. Note that a terminating `$` is used in the patterns to match the end of the file name.

I have tested the revised upgrade process on a Squeezebox Radio, and it operates as expected. User modified files that match the `grep` patterns in `move-after-upgrade` are appropriately moved aside, all others are left alone.

I would like to test the process on a Controller, but I am unlikely to be able to that for a few days. I do not have a Touch to test on. I would not expect to find any difference in operation on these devices.

There would be a negative impact on users who routinely modify their start up scripts, and expect them to remain unchanged. The only modifications that I have become aware of are those made to the `wlan` script over the years. But as far as I am aware,  these are not all accomodated by the Community Firmware.

I think a warning/alert should be included in the appropriate change log.

