### PR TITLE
Atheros wifi driver - Log WMI "Set BSS filter command" - Radio only - Amended

### DIFF
--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/0012-log-wmi-set-BSS-filter-command.patch
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/0012-log-wmi-set-BSS-filter-command.patch
@@ -1,51 +1,93 @@
-From 55d294aab58eeea6e76a01ee98f259db6329461e Mon Sep 17 00:00:00 2001
+From 7c1fe0bf3c139b4e846ff567fd4508c1f1d2be27 Mon Sep 17 00:00:00 2001
 From: Martin Williams <martinr.williams@gmail.com>
-Date: Sun, 23 Feb 2025 21:25:35 +0000
-Subject: [PATCH] log-wmi-set-BSS-filter-command
+Date: Thu, 6 Mar 2025 23:05:19 +0000
+Subject: [PATCH 1/2] log-wmi-set-BSS-filter-command
 
 Logs the execution of the WMI BSS Filter command to assist in tracing the
 actions of wpa_supplicant, etc.
----
- AR6kSDK.build_sw.83/host/wmi/wmi.c | 31 ++++++++++++++++++++++++++++++
- 1 file changed, 31 insertions(+)
 
+Enabled with module parameter bss_filter_logging
+---
+ .../host/os/linux/ar6000_drv.c                |  3 ++
+ AR6kSDK.build_sw.83/host/wmi/wmi.c            | 35 +++++++++++++++++++
+ 2 files changed, 38 insertions(+)
+
+diff --git AR6kSDK.build_sw.83/host/os/linux/ar6000_drv.c AR6kSDK.build_sw.83/host/os/linux/ar6000_drv.c
+index 8178aa8..35782a8 100644
+--- AR6kSDK.build_sw.83/host/os/linux/ar6000_drv.c
++++ AR6kSDK.build_sw.83/host/os/linux/ar6000_drv.c
+@@ -192,6 +192,7 @@ unsigned int testmode =0;
+ #endif
+ unsigned int arp_logging = 0;
+ unsigned int dhcp_logging = 0;
++unsigned int bss_filter_logging = 0;
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0)
+ module_param_string(ifname, ifname, sizeof(ifname), 0644);
+@@ -215,6 +216,7 @@ module_param(allow_trace_signal, int, 0644);
+ module_param(processDot11Hdr, int, 0644);
+ module_param(arp_logging, int, 0644);
+ module_param(dhcp_logging, int, 0644);
++module_param(bss_filter_logging, int, 0644);
+ /* ATHENV */
+ #ifdef ANDROID_ENV
+ module_param(work_mode, int, 0644);
+@@ -262,6 +264,7 @@ MODULE_PARM(processDot11Hdr,"i");
+ MODULE_PARM(testmode, "i");
+ MODULE_PARM(arp_logging,"i");
+ MODULE_PARM(dhcp_logging,"i");
++MODULE_PARM(bss_filter_logging,"i");
+ #endif
+ #endif
+ 
 diff --git AR6kSDK.build_sw.83/host/wmi/wmi.c AR6kSDK.build_sw.83/host/wmi/wmi.c
-index b6afd24..6f7cef4 100644
+index b6afd24..e8c46f6 100644
 --- AR6kSDK.build_sw.83/host/wmi/wmi.c
 +++ AR6kSDK.build_sw.83/host/wmi/wmi.c
-@@ -2375,6 +2375,37 @@ wmi_bssfilter_cmd(struct wmi_t *wmip, A_UINT8 filter, A_UINT32 ieMask)
+@@ -165,6 +165,7 @@ unsigned int processDot11Hdr = 1;
+ #endif
+ #else
+ extern unsigned int processDot11Hdr;
++extern unsigned int bss_filter_logging;
+ #endif
+ 
+ /* ATHENV V9 +++ */
+@@ -2375,6 +2376,40 @@ wmi_bssfilter_cmd(struct wmi_t *wmip, A_UINT8 filter, A_UINT32 ieMask)
      void *osbuf;
      WMI_BSS_FILTER_CMD *cmd;
  
-+    /* log this command - to assist in tracing wpa_supplicant behaviour */
-+    switch (filter) {
-+    case (NONE_BSS_FILTER):
-+        A_PRINTF("AR6000 WMI - setting BSS filter to 'none' (%d - no beacons forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
-+        break;
-+    case (ALL_BSS_FILTER):
-+        A_PRINTF("AR6000 WMI - setting BSS filter to 'all' (%d - all beacons forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
-+        break;
-+    case (PROFILE_FILTER):
-+        A_PRINTF("AR6000 WMI - setting BSS filter to 'profile' (%d - only beacons matching profile forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
-+        break;
-+    case (ALL_BUT_PROFILE_FILTER):
-+        A_PRINTF("AR6000 WMI - setting BSS filter to 'not_profile' (%d - all but beacons matching profile forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
-+        break;
-+    case (CURRENT_BSS_FILTER):
-+        A_PRINTF("AR6000 WMI - setting BSS filter to 'bss' (%d - only beacons matching current BSS forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
-+        break;
-+    case (ALL_BUT_BSS_FILTER):
-+        A_PRINTF("AR6000 WMI - setting BSS filter to 'not_bss' (%d - all but beacons matching current BSS forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
-+        break;
-+    case (PROBED_SSID_FILTER):
-+        A_PRINTF("AR6000 WMI - setting BSS filter to 'ssid' (%d - beacons matching probed SSID forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
-+        break;
-+    default:
-+        A_PRINTF("AR6000 WMI - setting BSS filter to unrecognized value %d", filter);
-+        if (filter >= LAST_BSS_FILTER) {
-+            A_PRINTF(" - will be ignored");
++    /* Module parameter bss_filter_logging */
++    if (bss_filter_logging) {
++        /* log this command - to assist in tracing wpa_supplicant behaviour */
++        switch (filter) {
++        case (NONE_BSS_FILTER):
++            A_PRINTF("AR6000 WMI - setting BSS filter to 'none' (%d - no beacons forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
++            break;
++        case (ALL_BSS_FILTER):
++            A_PRINTF("AR6000 WMI - setting BSS filter to 'all' (%d - all beacons forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
++            break;
++        case (PROFILE_FILTER):
++            A_PRINTF("AR6000 WMI - setting BSS filter to 'profile' (%d - only beacons matching profile forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
++            break;
++        case (ALL_BUT_PROFILE_FILTER):
++            A_PRINTF("AR6000 WMI - setting BSS filter to 'not_profile' (%d - all but beacons matching profile forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
++            break;
++        case (CURRENT_BSS_FILTER):
++            A_PRINTF("AR6000 WMI - setting BSS filter to 'bss' (%d - only beacons matching current BSS forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
++            break;
++        case (ALL_BUT_BSS_FILTER):
++            A_PRINTF("AR6000 WMI - setting BSS filter to 'not_bss' (%d - all but beacons matching current BSS forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
++            break;
++        case (PROBED_SSID_FILTER):
++            A_PRINTF("AR6000 WMI - setting BSS filter to 'ssid' (%d - beacons matching probed SSID forwarded) - and ieMask to %u\n", filter, (u32)ieMask);
++            break;
++        default:
++            A_PRINTF("AR6000 WMI - setting BSS filter to unrecognized value %d", filter);
++            if (filter >= LAST_BSS_FILTER) {
++                A_PRINTF(" - will be ignored");
++            }
++            A_PRINTF("\n");
 +        }
-+        A_PRINTF("\n");
 +    }
 +
      if (filter >= LAST_BSS_FILTER) {


### PR DESCRIPTION
This is an amendment to the earlier change, _Atheros wifi driver - Log WMI "Set BSS filter command" - Radio only_ #24.

The logging can be very "noisy" if the WiFi is trying to reconnect to a "disappeared" AP, with entries appearing every second or so. This can conceal more than it reveals...

This amendment adds a module parameter, `bss_filter_logging`, that must be set to "1" to enable logging. This can be done, temporarily, by modifying the `loadAR6000l.sh` script.

I have built and tested this locally, it works as expected.
