### PR TITLE
SB Radio - WiFi Robustness applet - Add warning to Truncated Beacons display count 

### DIFF
--- a/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
+++ b/poky/meta-squeezeos/packages/atheros/atheros-ar6-module-src-1.1/SetupWifiRobustness/strings.txt
@@ -39,7 +39,7 @@ TRUNCATED_BCN_TITLE
 	EN	Truncated beacon count
 
 TRUNCATED_BCN_TEXT
-	EN	There are %s occurrences of 'truncated' WiFi beacons noted in the system log.\n\nThese are known to cause WiFi problems, although a handful seems to be tolerable.
+	EN	There are %s occurrences of 'truncated' WiFi beacons noted in the system log.\nThese are known to cause WiFi problems, although a handful seems to be tolerable.\n\nFALSE NEGATIVE WARNING\nHeavy system logging activity will cause 'truncated' WiFi beacon entries to be lost. This typically occurs when networking has failed. Set the 'net.http' log level, and perhaps other log settings, to 'Off' before relying on the count.\n
 
 MAXPERF_ENABLE
 	EN	Enable 'Power Maxperf'


### PR DESCRIPTION
The Truncated Beacons display count is determined by examining the system log. In circumstances where there is heavy system logging it is likely to be misleading. For example, a WiFi failure can generate significant 'http' error logging.

This change modifies the displayed text to warn the user about the potential for a "false negative", and to suggest that, as a minimum, `net.http` logging should be turned off.
