### PR TITLE
SB Radio: Add support for mounting the root filesystem via NFS (nfsroot)

### DIFF
--- a/poky/meta-squeezeos/conf/machine/baby.conf
+++ b/poky/meta-squeezeos/conf/machine/baby.conf
@@ -15,7 +15,7 @@ MACHINE_FEATURES = "kernel26 alsa screen"
 # use an uncompressed kernel for a faster boot
 KERNEL_IMAGETYPE = "Image"
 
-IMAGE_FSTYPES ?= "cramfs ubi"
+IMAGE_FSTYPES ?= "cramfs ubi tar.gz"
 
 IMAGE_UBI_MIN_IO_SIZE ?= "2048"
 IMAGE_UBI_PEB_SIZE ?= "131072"

--- a/poky/meta-squeezeos/conf/machine/fab4.conf
+++ b/poky/meta-squeezeos/conf/machine/fab4.conf
@@ -18,7 +18,7 @@ MACHINE_FEATURES = "kernel26 alsa screen"
 
 KERNEL_IMAGETYPE = "zImage"
 
-IMAGE_FSTYPES ?= "cramfs ubi"
+IMAGE_FSTYPES ?= "cramfs ubi tar.gz"
 
 IMAGE_UBI_MIN_IO_SIZE ?= "2048"
 IMAGE_UBI_PEB_SIZE ?= "131072"

--- a/poky/meta-squeezeos/conf/machine/jive.conf
+++ b/poky/meta-squeezeos/conf/machine/jive.conf
@@ -13,7 +13,7 @@ MACHINE_FEATURES = "kernel26 alsa screen"
 
 KERNEL_IMAGETYPE = "zImage"
 
-IMAGE_FSTYPES ?= "cramfs"
+IMAGE_FSTYPES ?= "cramfs tar.gz"
 SERIAL_CONSOLE = "-L 115200 tts/0"
 
 IMAGE_INSTALL += "uboot-env"

--- a/src/imx25/patches-no-rt/logitech/baby-enable-nfs-boot.patch
+++ b/src/imx25/patches-no-rt/logitech/baby-enable-nfs-boot.patch
@@ -1,0 +1,67 @@
+Enable mounting the root filesystem via NFS (nfsroot)
+
+The following kernel options are set:
+
+Networking ---> Networking options --->
+Enable: IP: kernel level autoconfiguration
+Enable: IP: DHCP support
+Enable: IP: BOOTP support
+
+File systems --->
+Enable: Network File Systems --->
+Enable: NFS file system support
+Enable: Provide NFSv3 client support
+Enable: Root file system on NFS
+
+Index: linux-2.6.26/.config
+===================================================================
+--- linux-2.6.26.orig/.config	2025-12-30 17:12:55.000000000 +0000
++++ linux-2.6.26/.config	2025-12-30 17:13:10.707404371 +0000
+@@ -1,7 +1,7 @@
+ #
+ # Automatically generated make config: don't edit
+ # Linux kernel version: 2.6.26.8
+-# Tue Aug 18 15:32:12 2009
++# Tue Dec 30 17:00:27 2025
+ #
+ CONFIG_ARM=y
+ CONFIG_SYS_SUPPORTS_APM_EMULATION=y
+@@ -309,7 +309,10 @@
+ # CONFIG_IP_MULTICAST is not set
+ # CONFIG_IP_ADVANCED_ROUTER is not set
+ CONFIG_IP_FIB_HASH=y
+-# CONFIG_IP_PNP is not set
++CONFIG_IP_PNP=y
++CONFIG_IP_PNP_DHCP=y
++CONFIG_IP_PNP_BOOTP=y
++# CONFIG_IP_PNP_RARP is not set
+ # CONFIG_NET_IPIP is not set
+ # CONFIG_NET_IPGRE is not set
+ # CONFIG_ARPD is not set
+@@ -1090,7 +1093,25 @@
+ # CONFIG_ROMFS_FS is not set
+ # CONFIG_SYSV_FS is not set
+ # CONFIG_UFS_FS is not set
+-# CONFIG_NETWORK_FILESYSTEMS is not set
++CONFIG_NETWORK_FILESYSTEMS=y
++CONFIG_NFS_FS=y
++CONFIG_NFS_V3=y
++# CONFIG_NFS_V3_ACL is not set
++# CONFIG_NFS_V4 is not set
++# CONFIG_NFSD is not set
++CONFIG_ROOT_NFS=y
++CONFIG_LOCKD=y
++CONFIG_LOCKD_V4=y
++CONFIG_NFS_COMMON=y
++CONFIG_SUNRPC=y
++# CONFIG_SUNRPC_BIND34 is not set
++# CONFIG_RPCSEC_GSS_KRB5 is not set
++# CONFIG_RPCSEC_GSS_SPKM3 is not set
++# CONFIG_SMB_FS is not set
++# CONFIG_CIFS is not set
++# CONFIG_NCP_FS is not set
++# CONFIG_CODA_FS is not set
++# CONFIG_AFS_FS is not set
+ 
+ #
+ # Partition Types

--- a/src/imx25/patches-no-rt/series
+++ b/src/imx25/patches-no-rt/series
@@ -1376,3 +1376,5 @@ logitech/baby-msp430-reset-if-no-i2c.patch
 
 # Fixes to run without RT kernel
 logitech/non-rt-fixes.patch
+
+logitech/baby-enable-nfs-boot.patch

--- a/src/imx25/patches/logitech/baby-enable-nfs-boot.patch
+++ b/src/imx25/patches/logitech/baby-enable-nfs-boot.patch
@@ -1,0 +1,67 @@
+Enable mounting the root filesystem via NFS (nfsroot)
+
+The following kernel options are set:
+
+Networking ---> Networking options --->
+Enable: IP: kernel level autoconfiguration
+Enable: IP: DHCP support
+Enable: IP: BOOTP support
+
+File systems --->
+Enable: Network File Systems --->
+Enable: NFS file system support
+Enable: Provide NFSv3 client support
+Enable: Root file system on NFS
+
+Index: linux-2.6.26/.config
+===================================================================
+--- linux-2.6.26.orig/.config	2025-12-29 17:30:03.000000000 +0000
++++ linux-2.6.26/.config	2025-12-29 17:31:01.123420155 +0000
+@@ -1,7 +1,7 @@
+ #
+ # Automatically generated make config: don't edit
+ # Linux kernel version: 2.6.26.8-rt16
+-# Tue Aug 11 10:37:31 2009
++# Mon Dec 29 17:23:11 2025
+ #
+ CONFIG_ARM=y
+ CONFIG_SYS_SUPPORTS_APM_EMULATION=y
+@@ -329,7 +329,10 @@
+ # CONFIG_IP_MULTICAST is not set
+ # CONFIG_IP_ADVANCED_ROUTER is not set
+ CONFIG_IP_FIB_HASH=y
+-# CONFIG_IP_PNP is not set
++CONFIG_IP_PNP=y
++CONFIG_IP_PNP_DHCP=y
++CONFIG_IP_PNP_BOOTP=y
++# CONFIG_IP_PNP_RARP is not set
+ # CONFIG_NET_IPIP is not set
+ # CONFIG_NET_IPGRE is not set
+ # CONFIG_ARPD is not set
+@@ -1113,7 +1116,25 @@
+ # CONFIG_ROMFS_FS is not set
+ # CONFIG_SYSV_FS is not set
+ # CONFIG_UFS_FS is not set
+-# CONFIG_NETWORK_FILESYSTEMS is not set
++CONFIG_NETWORK_FILESYSTEMS=y
++CONFIG_NFS_FS=y
++CONFIG_NFS_V3=y
++# CONFIG_NFS_V3_ACL is not set
++# CONFIG_NFS_V4 is not set
++# CONFIG_NFSD is not set
++CONFIG_ROOT_NFS=y
++CONFIG_LOCKD=y
++CONFIG_LOCKD_V4=y
++CONFIG_NFS_COMMON=y
++CONFIG_SUNRPC=y
++# CONFIG_SUNRPC_BIND34 is not set
++# CONFIG_RPCSEC_GSS_KRB5 is not set
++# CONFIG_RPCSEC_GSS_SPKM3 is not set
++# CONFIG_SMB_FS is not set
++# CONFIG_CIFS is not set
++# CONFIG_NCP_FS is not set
++# CONFIG_CODA_FS is not set
++# CONFIG_AFS_FS is not set
+ 
+ #
+ # Partition Types

--- a/src/imx25/patches/series
+++ b/src/imx25/patches/series
@@ -1389,3 +1389,4 @@ logitech/baby-dac-clko-stddrv.patch
 
 logitech/baby-debounce.patch
 logitech/msp430-init-seq.patch
+logitech/baby-enable-nfs-boot.patch


### PR DESCRIPTION
This proposed change allows the Radio's root filesystem to be mounted from a network file server. It is anticipated that this would be effected from a Redboot command prompt, in the context of debugging/investigation.

Normal users would not benefit from this change.

The functionality is already present in the stock SB Touch kernel. This change activates the relevant kernel configuration items in the Radio's kernel.

In addition, the change has the build system automatically generate a root filesystem tarball (for all platforms). This can be helpful when constructing a suitable network image.

For completeness, the change has been applied to both realtime and non-realtime kernel builds, although the non-realtime build is unlikely to be used. Both builds have been tested, and work as anticipated.

A suitable Redboot invocation might look like:

`exec -c "console=ttymxc1,115200 noinitrd ip=dhcp nfsroot=ip.adr.nfs.svr:/pathto/baby-rootfs,nfsvers=3,proto=tcp init=/sbin/init root=/dev/nfs ubi.mtd=1"
`

The Kernel uses an additional 300k of memory as a result of this configuration. I am not seeing a problem on my Radios as a result of this additional memory utilization, but if it were to become a problem then this change might be implemented as a simple "build option". (Perhaps, for example, by uncommenting something in the build tree).
